### PR TITLE
Allow for pathed wrapped commands

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -67,10 +67,16 @@ export default {
 		
 		line = line.substr(2).trim();
 		
-		var parts = line.split(/[\s\t]+/);
+		var parts = line.split(/[\s\t"']+/);
 		for (var i=parts.length-1; i>0; i--) {
-			if (parts[i].startsWith("-")) {
+			if (parts[i].startsWith("-") || parts[i].length == 0) {
 				continue;
+			}
+			
+			if (parts[i].indexOf("/") >= 0) {
+				// The wrapped command has a path. Extracting the command from the path
+				var fragments = parts[i].split("/");
+				return fragments[fragments.length - 1];
 			}
 			
 			return parts[i];


### PR DESCRIPTION
My environment provides a wrapper that points to a Ruby interpreter at a specific path. The path is quoted to prevent the usual issues around spaces in the path name. As a result, shebang-set-grammar fails to detect the language.

This change handles both situations. It handles quoted path by adding both double and single quotes to the first split. It then ignores any 0 length strings. It then detects the presence of "/" in the command string and returns the actual wrapped command without the path.

As a result, I can now open a file and Atom detects the grammar correctly, making me a much happier coder.